### PR TITLE
Swap FlashBagInterface with RequestStack

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -11,7 +11,7 @@
                 public="false" >
             <argument type="service" key="$twig" id="twig" />
             <argument type="service" key="$urlGenerator" id="router.default" />
-            <argument type="service" key="$flashBag" id="session.flash_bag" />
+            <argument type="service" key="$requestStack" id="request_stack" />
         </service>
         <service
                 id="Batenburg\ResponseFactoryBundle\Component\HttpFoundation\Contract\ResponseFactoryInterface"


### PR DESCRIPTION
This swaps the FlashBagInterface with a RequestStack.

Since `RequestStack->getSession()` returns a `SessionInterface` and `getFlashbag()` is only present on the base `Session` component, we check specificly for this type and otherwise ignore it.
It will trigger a `FlashBagNotSetException` further down for those cases.

This removes any deprecations that might trigger with Symfony 5.3 and up.

Closes #7 
